### PR TITLE
Fixes issue #2

### DIFF
--- a/R/G2Sd-internal.R
+++ b/R/G2Sd-internal.R
@@ -210,8 +210,8 @@ function(x){
                        if_else(meshsize<sedim[12] ,"silt","NA"))))))))))))))
                                                                                                                
 sediment <- all %>% group_by(samples,class) %>% summarise(value=sum(relative.value)) %>% 
-  spread(class,value) %>% select(samples,everything(),cgravel,mgravel,fgravel,vfgravel,vcsand,
-                                 csand,msand,fsand,vfsand,vcsilt,silt)
+  spread(class,value) %>% select(samples,everything(),any_of(c("cgravel","mgravel","fgravel","vfgravel","vcsand",
+                                 "csand","msand","fsand","vfsand","vcsilt","silt")))
     return(sediment)
   }
 .texture.sedim <- function(x){


### PR DESCRIPTION
A less strict selection (`any_of()`) in a `select()` function solves an error when coarse fractions are omitted.