### PR TITLE
Fixes issues with very fine or coarse sediments

### DIFF
--- a/G2Sd.Rproj
+++ b/G2Sd.Rproj
@@ -15,3 +15,4 @@ LaTeX: pdfLaTeX
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
+PackageCheckArgs: --no-manual

--- a/R/G2Sd-internal.R
+++ b/R/G2Sd-internal.R
@@ -230,7 +230,17 @@ sediment <- all %>% group_by(samples,class) %>% summarise(value=sum(relative.val
     mutate(sandmud=if_else(Sand==0 & Mud==0,0,
                    if_else(Sand>0 & Mud==0,10,
                    if_else(Sand==0 & Mud>0,0.01,
-                   if_else(Sand>0 & Mud>0,Sand/Mud,0))))) %>% 
+                   if_else(Sand>0 & Mud>0,Sand/Mud,0))))) 
+  
+  if(!"sandmud" %in% colnames(Texture)){
+    Texture <- Texture %>% mutate(sandmud = 0)
+  }
+  
+  if(!"Gravel" %in% colnames(Texture)){
+    Texture <- Texture %>% mutate(Gravel = 0)
+  }
+  
+  Texture <- Texture %>%
     mutate(texture=if_else(sandmud>=9 & Gravel>80, "Gravel",
                    if_else(sandmud>=9 & (Gravel>30 & Gravel<=80), "Sandy Gravel",
                    if_else(sandmud>=9 & (Gravel>5 & Gravel<=30), "Gravelly Sand",


### PR DESCRIPTION
There are errors with edge cases of very fine or coarse sediment - this solves them. Try, for example:

```
smallgranulo <- granulo 
rownames(smallgranulo) <- as.numeric(rownames(smallgranulo))/100
granstat(smallgranulo)
```